### PR TITLE
geom_alt props

### DIFF
--- a/data/421/182/465/421182465.geojson
+++ b/data/421/182/465/421182465.geojson
@@ -305,6 +305,9 @@
     },
     "wof:country":"TJ",
     "wof:created":1459009331,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55a0a564d43c22ce906a50b9517f1191",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
         }
     ],
     "wof:id":421182465,
-    "wof:lastmodified":1566666493,
+    "wof:lastmodified":1582314960,
     "wof:name":"Khorugh",
     "wof:parent_id":1091917883,
     "wof:placetype":"locality",

--- a/data/421/187/321/421187321.geojson
+++ b/data/421/187/321/421187321.geojson
@@ -604,6 +604,10 @@
     ],
     "wof:country":"TJ",
     "wof:created":1459009509,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b1309e7f59126499e8e9dce96f513b1",
     "wof:hierarchy":[
         {
@@ -622,7 +626,7 @@
         }
     ],
     "wof:id":421187321,
-    "wof:lastmodified":1566666489,
+    "wof:lastmodified":1582314960,
     "wof:name":"Dushanbe",
     "wof:parent_id":890430645,
     "wof:placetype":"locality",

--- a/data/421/196/459/421196459.geojson
+++ b/data/421/196/459/421196459.geojson
@@ -176,6 +176,9 @@
     },
     "wof:country":"TJ",
     "wof:created":1459009882,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"44f6b52c5628e3204d49de34a225bd4f",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":421196459,
-    "wof:lastmodified":1566666491,
+    "wof:lastmodified":1582314960,
     "wof:name":"Kuybyshevskiy",
     "wof:parent_id":1091916455,
     "wof:placetype":"locality",

--- a/data/856/325/13/85632513.geojson
+++ b/data/856/325/13/85632513.geojson
@@ -1019,7 +1019,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1092,7 +1091,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1582314955,
+    "wof:lastmodified":1583201638,
     "wof:name":"Tajikistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/325/13/85632513.geojson
+++ b/data/856/325/13/85632513.geojson
@@ -1018,8 +1018,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -1072,6 +1073,11 @@
     },
     "wof:country":"TJ",
     "wof:country_alpha3":"TJK",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"ee68bede8be7a302b7286b9d9f2bae31",
     "wof:hierarchy":[
         {
@@ -1086,7 +1092,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1566666296,
+    "wof:lastmodified":1582314955,
     "wof:name":"Tajikistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/788/99/85678899.geojson
+++ b/data/856/788/99/85678899.geojson
@@ -323,6 +323,9 @@
         "wk:page":"Gorno-Badakhshan Autonomous Region"
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86f74bfb829627a6406d78ce951acc5d",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1566666297,
+    "wof:lastmodified":1582314956,
     "wof:name":"Gorno-Badakhshan",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/05/85678905.geojson
+++ b/data/856/789/05/85678905.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Khatlon Region"
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"45bfe4ac826ed05cef4c9310c118f06e",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1566666299,
+    "wof:lastmodified":1582314956,
     "wof:name":"Khatlon",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/07/85678907.geojson
+++ b/data/856/789/07/85678907.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Districts of Republican Subordination"
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d43cb18da9f37e74d012f43e75a52d34",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1566666299,
+    "wof:lastmodified":1582314957,
     "wof:name":"Tadzhikistan Territories",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/13/85678913.geojson
+++ b/data/856/789/13/85678913.geojson
@@ -334,6 +334,9 @@
         "wk:page":"Sughd Region"
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7aed37e493bba68c0a02bd709b095825",
     "wof:hierarchy":[
         {
@@ -349,7 +352,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1566666300,
+    "wof:lastmodified":1582314957,
     "wof:name":"Leninabad",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/17/85678917.geojson
+++ b/data/856/789/17/85678917.geojson
@@ -526,6 +526,9 @@
         "iso:id":"TJ-DU"
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b1309e7f59126499e8e9dce96f513b1",
     "wof:hierarchy":[
         {
@@ -541,7 +544,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1566666299,
+    "wof:lastmodified":1582314956,
     "wof:name":"Dushanbe",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/859/037/19/85903719.geojson
+++ b/data/859/037/19/85903719.geojson
@@ -77,6 +77,9 @@
         "qs:id":479420
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f32ee7490b50eff319d45f9ca61e921",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379465,
+    "wof:lastmodified":1582314954,
     "wof:name":"Kalinino",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/21/85903721.geojson
+++ b/data/859/037/21/85903721.geojson
@@ -74,6 +74,9 @@
         "qs:id":984036
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35a55c9def1fe19300d069fda773c83b",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379465,
+    "wof:lastmodified":1582314954,
     "wof:name":"Ragunskiy",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/037/23/85903723.geojson
+++ b/data/859/037/23/85903723.geojson
@@ -104,6 +104,9 @@
         "qs:id":22717
     },
     "wof:country":"TJ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fad469b0608d8c3e641cee621e6461a5",
     "wof:hierarchy":[
         {
@@ -127,7 +130,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379465,
+    "wof:lastmodified":1582314954,
     "wof:name":"Yuzhnyy",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/430/645/890430645.geojson
+++ b/data/890/430/645/890430645.geojson
@@ -76,6 +76,9 @@
     },
     "wof:country":"TJ",
     "wof:created":1469051861,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b1309e7f59126499e8e9dce96f513b1",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":890430645,
-    "wof:lastmodified":1537304041,
+    "wof:lastmodified":1582314960,
     "wof:name":"Dushanbe",
     "wof:parent_id":-1,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.