### PR TITLE
tj concordances, placetype local, and more

### DIFF
--- a/data/109/191/631/7/1091916317.geojson
+++ b/data/109/191/631/7/1091916317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.549155,
-    "geom:area_square_m":5261367421.176814,
+    "geom:area_square_m":5261367259.172508,
     "geom:bbox":"67.997965,38.878695,69.659946,39.560859",
     "geom:latitude":39.210673,
     "geom:longitude":68.658284,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.AJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892845,
-    "wof:geomhash":"d8987f2c12d53c3dc95879c5f07e9415",
+    "wof:geomhash":"9da6368670199681aab0b9b87c664ea3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091916317,
-    "wof:lastmodified":1627522819,
+    "wof:lastmodified":1695886521,
     "wof:name":"Aini",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/636/3/1091916363.geojson
+++ b/data/109/191/636/3/1091916363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.308088,
-    "geom:area_square_m":2889045975.664731,
+    "geom:area_square_m":2889046016.125185,
     "geom:bbox":"69.911379,40.349781,70.795297,41.044367",
     "geom:latitude":40.679407,
     "geom:longitude":70.341739,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892847,
-    "wof:geomhash":"ead36e0265147fcc32331f68d4399bc4",
+    "wof:geomhash":"1df2ac142c99bfff3373649e2e1215d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1091916363,
-    "wof:lastmodified":1627522819,
+    "wof:lastmodified":1695886521,
     "wof:name":"Asht",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/640/9/1091916409.geojson
+++ b/data/109/191/640/9/1091916409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071851,
-    "geom:area_square_m":698192653.49947,
+    "geom:area_square_m":698192629.018025,
     "geom:bbox":"69.363127,38.034185,69.65728,38.402092",
     "geom:latitude":38.200667,
     "geom:longitude":69.515867,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892849,
-    "wof:geomhash":"38cf7cb9c5e467e17083f81076aeac8b",
+    "wof:geomhash":"12cfe25b40e3a83820dcbad5c13e410c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091916409,
-    "wof:lastmodified":1627522819,
+    "wof:lastmodified":1695886521,
     "wof:name":"Baljuvon",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/645/5/1091916455.geojson
+++ b/data/109/191/645/5/1091916455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091972,
-    "geom:area_square_m":897375959.143578,
+    "geom:area_square_m":897375990.661113,
     "geom:bbox":"68.617112,37.715693,69.096102,38.179056",
     "geom:latitude":37.901213,
     "geom:longitude":68.820432,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892850,
-    "wof:geomhash":"12e9bb7eb3e948e3cbbe0fc4606801bf",
+    "wof:geomhash":"5c7e0ec8ef8fd6dcbfecf38dc0ea1803",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916455,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886526,
     "wof:name":"Bokhtar",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/648/9/1091916489.geojson
+++ b/data/109/191/648/9/1091916489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229039,
-    "geom:area_square_m":2232087574.945243,
+    "geom:area_square_m":2232087895.637708,
     "geom:bbox":"68.953079,37.593614,69.468859,38.344434",
     "geom:latitude":37.987949,
     "geom:longitude":69.203574,
@@ -90,9 +90,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892852,
-    "wof:geomhash":"ecb8e92c8b65072443f6baeb7c5b1545",
+    "wof:geomhash":"e78727471f7eab85b91a822f70759c49",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1091916489,
-    "wof:lastmodified":1627522819,
+    "wof:lastmodified":1695886522,
     "wof:name":"Danghara",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/653/9/1091916539.geojson
+++ b/data/109/191/653/9/1091916539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057389,
-    "geom:area_square_m":552906412.743436,
+    "geom:area_square_m":552906404.161056,
     "geom:bbox":"69.752482,38.667813,70.198301,38.925678",
     "geom:latitude":38.81647,
     "geom:longitude":69.960159,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892853,
-    "wof:geomhash":"115d692ad67adc0c2cf3c783cdf8f24f",
+    "wof:geomhash":"d36cbade069b95d6f0eac5e3a12b62b4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916539,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886524,
     "wof:name":"Nurobod",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/658/7/1091916587.geojson
+++ b/data/109/191/658/7/1091916587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108845,
-    "geom:area_square_m":1052576554.570599,
+    "geom:area_square_m":1052576462.255453,
     "geom:bbox":"69.142764,38.378312,69.747726,38.782606",
     "geom:latitude":38.549903,
     "geom:longitude":69.484086,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892854,
-    "wof:geomhash":"e637a66c06108dbe8b6639f62057c846",
+    "wof:geomhash":"3b7ef17bc6a03c9e0a5dd686ecf4568a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091916587,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886522,
     "wof:name":"Fayzobod",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/661/5/1091916615.geojson
+++ b/data/109/191/661/5/1091916615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.192556,
-    "geom:area_square_m":1831202784.198061,
+    "geom:area_square_m":1831202597.418163,
     "geom:bbox":"68.911599,39.425448,69.359833,40.120262",
     "geom:latitude":39.72708,
     "geom:longitude":69.137361,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892856,
-    "wof:geomhash":"4733c87dde07bdf0c78a8bbc89dafbf6",
+    "wof:geomhash":"c1de2df1388cc0a3378efeaa51f82d68",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1091916615,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886522,
     "wof:name":"Ghonchi",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/665/9/1091916659.geojson
+++ b/data/109/191/665/9/1091916659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.39482,
-    "geom:area_square_m":3787790760.27662,
+    "geom:area_square_m":3787790760.276509,
     "geom:bbox":"69.6213301387,38.8202772338,70.6885577316,39.585345806",
     "geom:latitude":39.116218,
     "geom:longitude":70.229632,
@@ -234,9 +234,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892857,
-    "wof:geomhash":"10942a605c0dae45648214f787a9da05",
+    "wof:geomhash":"95a0c3ac27e1373686ae7215ab8e4ac3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -246,7 +247,7 @@
         }
     ],
     "wof:id":1091916659,
-    "wof:lastmodified":1566666475,
+    "wof:lastmodified":1695886576,
     "wof:name":"Rasht",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/670/5/1091916705.geojson
+++ b/data/109/191/670/5/1091916705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096444,
-    "geom:area_square_m":939593575.452733,
+    "geom:area_square_m":939593597.74227,
     "geom:bbox":"68.421326,37.623306,68.787226,38.297981",
     "geom:latitude":38.010857,
     "geom:longitude":68.576255,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892859,
-    "wof:geomhash":"9d8c9f0972622fba7e07276cfd1a4644",
+    "wof:geomhash":"37c18377b9d80c5b631a6055b95c1454",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916705,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886523,
     "wof:name":"Khuroson",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/674/9/1091916749.geojson
+++ b/data/109/191/674/9/1091916749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069475,
-    "geom:area_square_m":672689743.9831,
+    "geom:area_square_m":672689538.407864,
     "geom:bbox":"68.295818,38.234297,68.612156,38.648626",
     "geom:latitude":38.459838,
     "geom:longitude":68.456436,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892860,
-    "wof:geomhash":"498fdaec01d5566f73482b2cc956928a",
+    "wof:geomhash":"59b2425d29eb3055734a5cb61f60ccef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916749,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886523,
     "wof:name":"Hissor",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/678/7/1091916787.geojson
+++ b/data/109/191/678/7/1091916787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.28524,
-    "geom:area_square_m":2686715655.256231,
+    "geom:area_square_m":2686716280.025453,
     "geom:bbox":"69.247551,40.083874,70.274163,40.723792",
     "geom:latitude":40.381434,
     "geom:longitude":69.752571,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892862,
-    "wof:geomhash":"0574f78a031518071dd5d10a2a59edd2",
+    "wof:geomhash":"366ea9adbdfdb4362a692a7c1e58063d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091916787,
-    "wof:lastmodified":1627522819,
+    "wof:lastmodified":1695886522,
     "wof:name":"Bobojon Ghafurov",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/681/3/1091916813.geojson
+++ b/data/109/191/681/3/1091916813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.299932,
-    "geom:area_square_m":2907199401.313197,
+    "geom:area_square_m":2907199917.30552,
     "geom:bbox":"69.592574,38.055003,70.4533,38.699032",
     "geom:latitude":38.38236,
     "geom:longitude":69.956563,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.HV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892863,
-    "wof:geomhash":"8098f723cc5ebd7b62e8d163953741c0",
+    "wof:geomhash":"7e5cf3ede2fb1c135c3d961ff832cb1d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091916813,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886523,
     "wof:name":"Khovaling",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/684/1/1091916841.geojson
+++ b/data/109/191/684/1/1091916841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09142,
-    "geom:area_square_m":864685339.504172,
+    "geom:area_square_m":864685339.503934,
     "geom:bbox":"70.3227214159,39.778113,70.992426,40.2833711246",
     "geom:latitude":40.100091,
     "geom:longitude":70.605083,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.IR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892865,
-    "wof:geomhash":"c3902cac1f51a849a3dfda76d4fa1ffd",
+    "wof:geomhash":"994e96e8e9fa6c9d1327d1d85e5a3eec",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1091916841,
-    "wof:lastmodified":1566666473,
+    "wof:lastmodified":1695886576,
     "wof:name":"Isfara",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/685/9/1091916859.geojson
+++ b/data/109/191/685/9/1091916859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.185374,
-    "geom:area_square_m":1832297472.836549,
+    "geom:area_square_m":1832297442.692581,
     "geom:bbox":"71.428848,36.672037,72.822137,37.260563",
     "geom:latitude":36.930112,
     "geom:longitude":71.94121,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.BK.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892866,
-    "wof:geomhash":"5da5a99c6627439f0ceb03a4d6fd599f",
+    "wof:geomhash":"1d73c887662afd998606b6069e8e72f8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091916859,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886523,
     "wof:name":"Ishkoshim",
     "wof:parent_id":85678899,
     "wof:placetype":"county",

--- a/data/109/191/689/7/1091916897.geojson
+++ b/data/109/191/689/7/1091916897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106361,
-    "geom:area_square_m":1043928493.221983,
+    "geom:area_square_m":1043928519.533033,
     "geom:bbox":"68.192787,37.006864,68.531281,37.806959",
     "geom:latitude":37.461423,
     "geom:longitude":68.372925,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.DZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892868,
-    "wof:geomhash":"b09948061be90c786692f40ea67f406d",
+    "wof:geomhash":"a6bc2ed1cc3b0d9cd62070e2fd87e7a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091916897,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886523,
     "wof:name":"Jilikul",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/693/9/1091916939.geojson
+++ b/data/109/191/693/9/1091916939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.557434,
-    "geom:area_square_m":5341015335.019833,
+    "geom:area_square_m":5341015156.167687,
     "geom:bbox":"70.909036,38.85031,72.244434,39.625094",
     "geom:latitude":39.20638,
     "geom:longitude":71.594325,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.DZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892869,
-    "wof:geomhash":"7ec8f8f319ab4cb24f6a492ac2411317",
+    "wof:geomhash":"5bb389117f3a7714357ea286ec45156d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091916939,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886523,
     "wof:name":"Jirgatol",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/697/5/1091916975.geojson
+++ b/data/109/191/697/5/1091916975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.181877,
-    "geom:area_square_m":1786797649.742381,
+    "geom:area_square_m":1786797295.621361,
     "geom:bbox":"68.001081,36.922609,68.396599,37.828202",
     "geom:latitude":37.3907,
     "geom:longitude":68.173047,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892871,
-    "wof:geomhash":"57775cef07f04b5cec7d2921e73f2a92",
+    "wof:geomhash":"cf2fca24d0444c5b00650546bac1c06b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091916975,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886524,
     "wof:name":"Qubodiyon",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/702/1/1091917021.geojson
+++ b/data/109/191/702/1/1091917021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250823,
-    "geom:area_square_m":2429288777.476397,
+    "geom:area_square_m":2429288351.50779,
     "geom:bbox":"70.244612,37.937125,71.270313,38.742099",
     "geom:latitude":38.438987,
     "geom:longitude":70.675314,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.BK.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892873,
-    "wof:geomhash":"afc3ac441cbc1c160e10e84076bb4ea3",
+    "wof:geomhash":"71ebab06a3244791c5669bc0672de566",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091917021,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886523,
     "wof:name":"Darvoz",
     "wof:parent_id":85678899,
     "wof:placetype":"county",

--- a/data/109/191/706/7/1091917067.geojson
+++ b/data/109/191/706/7/1091917067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087261,
-    "geom:area_square_m":823442453.344426,
+    "geom:area_square_m":823442348.518877,
     "geom:bbox":"69.978691,40.114063,70.577972,40.399583",
     "geom:latitude":40.256605,
     "geom:longitude":70.294343,
@@ -180,9 +180,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.KC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892874,
-    "wof:geomhash":"b854cac867cdd633589c68ff70c8b643",
+    "wof:geomhash":"37d53a0717afc45e8e42eb0ed91781c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1091917067,
-    "wof:lastmodified":1636494890,
+    "wof:lastmodified":1695886622,
     "wof:name":"Konibodom",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/707/7/1091917077.geojson
+++ b/data/109/191/707/7/1091917077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.402536,
-    "geom:area_square_m":3879468369.46218,
+    "geom:area_square_m":3879468369.46271,
     "geom:bbox":"68.8122742246,38.3260416343,69.8952821806,39.1440208773",
     "geom:latitude":38.792942,
     "geom:longitude":69.30433,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.KR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892876,
-    "wof:geomhash":"ef00937d836fa65a9da7d13cc791c5c8",
+    "wof:geomhash":"fe676b4e4e3c5fcfd15075b4742dbf9e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1091917077,
-    "wof:lastmodified":1566666465,
+    "wof:lastmodified":1695886575,
     "wof:name":"Vahdat",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/707/9/1091917079.geojson
+++ b/data/109/191/707/9/1091917079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085443,
-    "geom:area_square_m":838755467.850137,
+    "geom:area_square_m":838755674.070041,
     "geom:bbox":"68.455508,37.348805,69.065939,37.651743",
     "geom:latitude":37.450035,
     "geom:longitude":68.725685,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892877,
-    "wof:geomhash":"21d2b32e4461562a6e910780f25a3a61",
+    "wof:geomhash":"4560512b1c1654fe7cff850918ee9319",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091917079,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886524,
     "wof:name":"Jaloliddini Rumi",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/708/1/1091917081.geojson
+++ b/data/109/191/708/1/1091917081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.453986,
-    "geom:area_square_m":4337787463.819501,
+    "geom:area_square_m":4337787777.190161,
     "geom:bbox":"68.987871,39.167808,70.642987,39.62316",
     "geom:latitude":39.400693,
     "geom:longitude":69.764281,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892879,
-    "wof:geomhash":"26f95048d567910ea725a362a800029d",
+    "wof:geomhash":"01a77ed88ae1ffb9ae79eb0c660d6fd3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091917081,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886524,
     "wof:name":"Kuhistoni Mastchoh",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/710/9/1091917109.geojson
+++ b/data/109/191/710/9/1091917109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034264,
-    "geom:area_square_m":334318233.955673,
+    "geom:area_square_m":334318233.955658,
     "geom:bbox":"69.6260990988,37.7429771561,69.8652298249,38.0792405384",
     "geom:latitude":37.901068,
     "geom:longitude":69.748263,
@@ -174,9 +174,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.KC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892880,
-    "wof:geomhash":"8a588cca982bc2315789ee78ca50d4b9",
+    "wof:geomhash":"4fd8fa8f858631397a622de198678a0e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":1091917109,
-    "wof:lastmodified":1566666476,
+    "wof:lastmodified":1695886576,
     "wof:name":"Kulob",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/713/5/1091917135.geojson
+++ b/data/109/191/713/5/1091917135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081542,
-    "geom:area_square_m":802542658.125364,
+    "geom:area_square_m":802542790.874437,
     "geom:bbox":"68.222581,37.028337,69.029273,37.37935",
     "geom:latitude":37.25524,
     "geom:longitude":68.592577,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892882,
-    "wof:geomhash":"f48c5db5aaf2f785e11fa8f8cbb1dc27",
+    "wof:geomhash":"eed69cbfee1b510ab483e33073fd3e1d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091917135,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886526,
     "wof:name":"Qumsangir",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/718/1/1091917181.geojson
+++ b/data/109/191/718/1/1091917181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03614,
-    "geom:area_square_m":353356549.980039,
+    "geom:area_square_m":353356549.979989,
     "geom:bbox":"68.5062895186,37.6216782751,68.7714791864,37.8572777628",
     "geom:latitude":37.746904,
     "geom:longitude":68.631728,
@@ -198,9 +198,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.KT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892884,
-    "wof:geomhash":"cba3c3cb932918625a12603345de379c",
+    "wof:geomhash":"fd5a0b62f8900dc2843a9ea27a06db55",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":1091917181,
-    "wof:lastmodified":1566666477,
+    "wof:lastmodified":1695886576,
     "wof:name":"Qurghonteppa",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/722/1/1091917221.geojson
+++ b/data/109/191/722/1/1091917221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109913,
-    "geom:area_square_m":1032171777.815911,
+    "geom:area_square_m":1032171380.335845,
     "geom:bbox":"69.21195,40.273501,69.868494,40.794525",
     "geom:latitude":40.58399,
     "geom:longitude":69.461772,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892885,
-    "wof:geomhash":"0407b5f30ae5e5593e5816cf6da60560",
+    "wof:geomhash":"34ff84fc717bd703a48d719eb2a6c23c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091917221,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886525,
     "wof:name":"Mastchoh",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/724/9/1091917249.geojson
+++ b/data/109/191/724/9/1091917249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.076617,
-    "geom:area_square_m":750240237.109235,
+    "geom:area_square_m":750240140.730444,
     "geom:bbox":"69.348934,37.491652,70.132601,37.793716",
     "geom:latitude":37.636083,
     "geom:longitude":69.724709,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892887,
-    "wof:geomhash":"bfec352c4e3a0cd3795b5d05dd7d2f6b",
+    "wof:geomhash":"1288c8d4d4c0d0ee9f65838a856ae5c7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091917249,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886525,
     "wof:name":"Mir Said Ali Hamadoni",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/729/5/1091917295.geojson
+++ b/data/109/191/729/5/1091917295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134668,
-    "geom:area_square_m":1310621313.995721,
+    "geom:area_square_m":1310621148.814022,
     "geom:bbox":"69.812475,37.869492,70.321529,38.334514",
     "geom:latitude":38.087792,
     "geom:longitude":70.103367,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892888,
-    "wof:geomhash":"f6c8e3cc547a03c00dc293f767519188",
+    "wof:geomhash":"008efcdcffe7f3c53d016d52604bcddf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091917295,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886525,
     "wof:name":"Mu'minobod",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/733/9/1091917339.geojson
+++ b/data/109/191/733/9/1091917339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.884008,
-    "geom:area_square_m":37701512398.115082,
+    "geom:area_square_m":37701512336.053116,
     "geom:bbox":"72.006661,37.221767,75.153826,39.473738",
     "geom:latitude":38.274414,
     "geom:longitude":73.508772,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.BK.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892890,
-    "wof:geomhash":"c84714dd4e203f6b5443a09cf74274ba",
+    "wof:geomhash":"5704700dbdea56756c8bbe6644f872d6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091917339,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886525,
     "wof:name":"Murghob",
     "wof:parent_id":85678899,
     "wof:placetype":"county",

--- a/data/109/191/738/1/1091917381.geojson
+++ b/data/109/191/738/1/1091917381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049461,
-    "geom:area_square_m":467754288.635539,
+    "geom:area_square_m":467754339.305941,
     "geom:bbox":"69.168713,39.911366,69.459518,40.245666",
     "geom:latitude":40.11022,
     "geom:longitude":69.319322,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892891,
-    "wof:geomhash":"ddb39ac32390232706870bf028fe03c6",
+    "wof:geomhash":"ffa4c4016c41c8e6ad3f080fc6384933",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091917381,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886526,
     "wof:name":"Spitamen",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/742/1/1091917421.geojson
+++ b/data/109/191/742/1/1091917421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044632,
-    "geom:area_square_m":432674230.828524,
+    "geom:area_square_m":432674075.036062,
     "geom:bbox":"69.126909,38.266943,69.542323,38.450941",
     "geom:latitude":38.371911,
     "geom:longitude":69.32349,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.NC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892893,
-    "wof:geomhash":"59529c764d9e29d958859245e6018830",
+    "wof:geomhash":"24093465d11fdf68dc54189929538406",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091917421,
-    "wof:lastmodified":1627522821,
+    "wof:lastmodified":1695886526,
     "wof:name":"Norak",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/746/3/1091917463.geojson
+++ b/data/109/191/746/3/1091917463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.138667,
-    "geom:area_square_m":1361963937.032793,
+    "geom:area_square_m":1361963831.325078,
     "geom:bbox":"69.027769,37.103304,69.453934,37.660615",
     "geom:latitude":37.409453,
     "geom:longitude":69.257181,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892894,
-    "wof:geomhash":"1cdc0b2ccba205c40b8e7640597da112",
+    "wof:geomhash":"8cd1069e8488396a59f091f858bfa1b6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091917463,
-    "wof:lastmodified":1627522820,
+    "wof:lastmodified":1695886524,
     "wof:name":"Farkhor",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/750/7/1091917507.geojson
+++ b/data/109/191/750/7/1091917507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.376412,
-    "geom:area_square_m":3599809532.095223,
+    "geom:area_square_m":3599809532.095337,
     "geom:bbox":"67.342012,39.000517,68.2222928227,39.659689",
     "geom:latitude":39.337708,
     "geom:longitude":67.80875,
@@ -168,9 +168,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.PR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892896,
-    "wof:geomhash":"81c635d7b983efd7af569fbe6417e200",
+    "wof:geomhash":"f6daea8b007d192447944912a93df0a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1091917507,
-    "wof:lastmodified":1566666472,
+    "wof:lastmodified":1695886575,
     "wof:name":"Panjakent",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/754/7/1091917547.geojson
+++ b/data/109/191/754/7/1091917547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030775,
-    "geom:area_square_m":302866889.591222,
+    "geom:area_square_m":302867033.388781,
     "geom:bbox":"68.997331,37.093064,69.273971,37.419839",
     "geom:latitude":37.261606,
     "geom:longitude":69.136043,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.PJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892898,
-    "wof:geomhash":"826ee1172c7c6514c479779f763075c8",
+    "wof:geomhash":"3deb26b683e23897eb4f4c2de36a06b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091917547,
-    "wof:lastmodified":1636494891,
+    "wof:lastmodified":1695886622,
     "wof:name":"Panj",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/759/1/1091917591.geojson
+++ b/data/109/191/759/1/1091917591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03619,
-    "geom:area_square_m":342348840.287461,
+    "geom:area_square_m":342348712.189203,
     "geom:bbox":"69.360009,39.914014,69.620092,40.232023",
     "geom:latitude":40.090805,
     "geom:longitude":69.480082,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.DR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892899,
-    "wof:geomhash":"243975776729ca6c3b36ff3973f181c3",
+    "wof:geomhash":"01b811da13b99c5bb0fad9f03687dba8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1091917591,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886527,
     "wof:name":"Jabbor Rasulov",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/763/5/1091917635.geojson
+++ b/data/109/191/763/5/1091917635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05242,
-    "geom:area_square_m":505870767.396587,
+    "geom:area_square_m":505870908.400891,
     "geom:bbox":"69.609264,38.517201,69.917975,38.870076",
     "geom:latitude":38.699147,
     "geom:longitude":69.772468,
@@ -96,9 +96,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.RC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892901,
-    "wof:geomhash":"9293d18b1e7eb8b1c0514ff620d7db09",
+    "wof:geomhash":"1e501bb59589979c3d733b98e7560a28",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1091917635,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886527,
     "wof:name":"Roghun",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/766/1/1091917661.geojson
+++ b/data/109/191/766/1/1091917661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.469999,
-    "geom:area_square_m":4629876361.060793,
+    "geom:area_square_m":4629876265.85849,
     "geom:bbox":"71.453891,36.821721,72.865775,37.542213",
     "geom:latitude":37.187697,
     "geom:longitude":72.170936,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.BK.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892902,
-    "wof:geomhash":"e0becb075d5b2adef2de5a35f7b8002b",
+    "wof:geomhash":"77970bfc52147030f618fe409e84d6c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091917661,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886527,
     "wof:name":"Roshtqal'a",
     "wof:parent_id":85678899,
     "wof:placetype":"county",

--- a/data/109/191/770/7/1091917707.geojson
+++ b/data/109/191/770/7/1091917707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.597756,
-    "geom:area_square_m":5823229519.439335,
+    "geom:area_square_m":5823229519.439577,
     "geom:bbox":"71.251881,37.5411276237,72.7588671479,38.4671645106",
     "geom:latitude":38.015327,
     "geom:longitude":72.146212,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.BK.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892904,
-    "wof:geomhash":"d4e8eed11e1d061035842fd717002e2d",
+    "wof:geomhash":"60e799a5c8403164d528ea82fa9f78b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091917707,
-    "wof:lastmodified":1566666470,
+    "wof:lastmodified":1695886575,
     "wof:name":"Rushon",
     "wof:parent_id":85678899,
     "wof:placetype":"county",

--- a/data/109/191/776/5/1091917765.geojson
+++ b/data/109/191/776/5/1091917765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164948,
-    "geom:area_square_m":1620571380.061541,
+    "geom:area_square_m":1620571381.804731,
     "geom:bbox":"67.784204,36.928813,68.201149,37.935425",
     "geom:latitude":37.386758,
     "geom:longitude":67.970086,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.ST"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892905,
-    "wof:geomhash":"cf25d8ba17389a4ff2673d7b7db33f06",
+    "wof:geomhash":"4d03bca4454a8edc46be02b0b497a3f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091917765,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886527,
     "wof:name":"Shahritus",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/778/9/1091917789.geojson
+++ b/data/109/191/778/9/1091917789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079445,
-    "geom:area_square_m":766227136.516857,
+    "geom:area_square_m":766226914.546305,
     "geom:bbox":"68.178878,38.512691,68.580258,38.922101",
     "geom:latitude":38.739754,
     "geom:longitude":68.409218,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892907,
-    "wof:geomhash":"4fab1234b5a2b8d00217811dc62012c3",
+    "wof:geomhash":"c6f7f75df4302d25476eb014542459e7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091917789,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886527,
     "wof:name":"Shahrinav",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/783/7/1091917837.geojson
+++ b/data/109/191/783/7/1091917837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.129303,
-    "geom:area_square_m":1231187303.709652,
+    "geom:area_square_m":1231187355.01965,
     "geom:bbox":"68.434281,39.440643,68.948635,39.981127",
     "geom:latitude":39.642011,
     "geom:longitude":68.748532,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892908,
-    "wof:geomhash":"eee4f21ec21f8a40f59a2ac3c513589a",
+    "wof:geomhash":"cb21ee0368c79d72945a21d7b95bb901",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091917837,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886527,
     "wof:name":"Shahriston",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/788/3/1091917883.geojson
+++ b/data/109/191/788/3/1091917883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.47677,
-    "geom:area_square_m":4673882165.599213,
+    "geom:area_square_m":4673882303.698977,
     "geom:bbox":"71.475043,37.238502,72.753009,37.887282",
     "geom:latitude":37.551119,
     "geom:longitude":72.130064,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.BK.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892910,
-    "wof:geomhash":"2ad748e63e9b45319e007d00d160468e",
+    "wof:geomhash":"b5bda53638087e69347be67a57b47251",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091917883,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886527,
     "wof:name":"Shughnon",
     "wof:parent_id":85678899,
     "wof:placetype":"county",

--- a/data/109/191/791/3/1091917913.geojson
+++ b/data/109/191/791/3/1091917913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.134056,
-    "geom:area_square_m":1310486603.402887,
+    "geom:area_square_m":1310486816.811375,
     "geom:bbox":"69.761042,37.522754,70.303519,37.973673",
     "geom:latitude":37.760267,
     "geom:longitude":70.046777,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.SB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892911,
-    "wof:geomhash":"e40a6b9fae9573e31ac0e2f431947f26",
+    "wof:geomhash":"361cbf7bb4a7f207d0c8d3c35d492879",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091917913,
-    "wof:lastmodified":1627522822,
+    "wof:lastmodified":1695886528,
     "wof:name":"Shuroobod",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/795/7/1091917957.geojson
+++ b/data/109/191/795/7/1091917957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056959,
-    "geom:area_square_m":555573127.719672,
+    "geom:area_square_m":555573393.77221,
     "geom:bbox":"69.316687,37.753357,69.667486,38.077565",
     "geom:latitude":37.92468,
     "geom:longitude":69.492401,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892913,
-    "wof:geomhash":"14aa23d5aa83d8cc17c3eefaf3b30719",
+    "wof:geomhash":"a0bc5c213830b94178419acddea879bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091917957,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886528,
     "wof:name":"Temurmalik",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/799/3/1091917993.geojson
+++ b/data/109/191/799/3/1091917993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.666136,
-    "geom:area_square_m":6424962653.863017,
+    "geom:area_square_m":6424963094.695189,
     "geom:bbox":"70.011149,38.388004,72.063473,39.067095",
     "geom:latitude":38.737192,
     "geom:longitude":71.100132,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.TV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892914,
-    "wof:geomhash":"6f04923dcd1258b290d3454dca425f89",
+    "wof:geomhash":"61da43afb57bcea05cf6be3500ebbdcd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091917993,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886528,
     "wof:name":"Tavildara",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/803/7/1091918037.geojson
+++ b/data/109/191/803/7/1091918037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.216959,
-    "geom:area_square_m":2079864284.242291,
+    "geom:area_square_m":2079864377.232198,
     "geom:bbox":"70.598213,38.896184,71.220304,39.52667",
     "geom:latitude":39.169866,
     "geom:longitude":70.83617,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.TJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892915,
-    "wof:geomhash":"aeaa615db04b46de5e66631888e59fc2",
+    "wof:geomhash":"b099030c752e8926e06a9cbf8ab782c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1091918037,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886528,
     "wof:name":"Tojikobod",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/805/5/1091918055.geojson
+++ b/data/109/191/805/5/1091918055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115907,
-    "geom:area_square_m":1120360424.852947,
+    "geom:area_square_m":1120360424.853136,
     "geom:bbox":"68.056901,38.239560353,68.3727810309,38.8860416085",
     "geom:latitude":38.582279,
     "geom:longitude":68.21372,
@@ -150,9 +150,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892917,
-    "wof:geomhash":"bb08194265c4d954a1511f4ad3500997",
+    "wof:geomhash":"c21da44be1e9fc00a0495c60eb0993a0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1091918055,
-    "wof:lastmodified":1566666469,
+    "wof:lastmodified":1695886575,
     "wof:name":"Tursunzoda",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/809/3/1091918093.geojson
+++ b/data/109/191/809/3/1091918093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06157,
-    "geom:area_square_m":583886695.799145,
+    "geom:area_square_m":583886695.799243,
     "geom:bbox":"68.845852,39.6475059193,69.1534386175,40.1379850723",
     "geom:latitude":39.92079,
     "geom:longitude":68.987039,
@@ -171,9 +171,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.UR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892919,
-    "wof:geomhash":"69f6fc096dccffb876506734d8807b6f",
+    "wof:geomhash":"ead0c194da3acf6a35bf0cc36c073dc4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":1091918093,
-    "wof:lastmodified":1566666474,
+    "wof:lastmodified":1695886576,
     "wof:name":"Istaravshan",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/814/1/1091918141.geojson
+++ b/data/109/191/814/1/1091918141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11893,
-    "geom:area_square_m":1164815516.004003,
+    "geom:area_square_m":1164815847.854654,
     "geom:bbox":"68.571801,37.456685,69.082429,37.827581",
     "geom:latitude":37.620312,
     "geom:longitude":68.861394,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892920,
-    "wof:geomhash":"898827bc98ce5b4a546c69c923399437",
+    "wof:geomhash":"dd6c06874182e7fe989c92d21810a386",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091918141,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886528,
     "wof:name":"Vakhsh",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/817/5/1091918175.geojson
+++ b/data/109/191/817/5/1091918175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.461459,
-    "geom:area_square_m":4474906792.689508,
+    "geom:area_square_m":4474906823.109959,
     "geom:bbox":"71.175663,37.947022,72.292242,38.759216",
     "geom:latitude":38.349008,
     "geom:longitude":71.789865,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.BK.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892922,
-    "wof:geomhash":"31136567fefdbe32f3b89430fd406fe7",
+    "wof:geomhash":"5efdbb969d6013bb9b3d72ca824aba96",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091918175,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886528,
     "wof:name":"Vanj",
     "wof:parent_id":85678899,
     "wof:placetype":"county",

--- a/data/109/191/821/5/1091918215.geojson
+++ b/data/109/191/821/5/1091918215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170066,
-    "geom:area_square_m":1638131496.140706,
+    "geom:area_square_m":1638131523.355689,
     "geom:bbox":"68.449129,38.600007,69.007572,39.033501",
     "geom:latitude":38.832046,
     "geom:longitude":68.74421,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.VA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892923,
-    "wof:geomhash":"f37d14da4bcde65dcbbdb4deda883c5b",
+    "wof:geomhash":"4a1e02c508e48421a831ecc9f2d78e1c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091918215,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886529,
     "wof:name":"Varzob",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/109/191/826/1/1091918261.geojson
+++ b/data/109/191/826/1/1091918261.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078077,
-    "geom:area_square_m":762870133.584538,
+    "geom:area_square_m":762869969.456916,
     "geom:bbox":"69.329887,37.616962,69.786832,38.081164",
     "geom:latitude":37.797566,
     "geom:longitude":69.560289,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.VO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892925,
-    "wof:geomhash":"2800950686a31d8d0d355cb9fa8b6b68",
+    "wof:geomhash":"0f9be10c60c91bacd42ad74a1c829381",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091918261,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886529,
     "wof:name":"Vose",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/830/1/1091918301.geojson
+++ b/data/109/191/830/1/1091918301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.098119,
-    "geom:area_square_m":953781868.2143,
+    "geom:area_square_m":953781661.111845,
     "geom:bbox":"68.712628,37.962492,69.130307,38.374226",
     "geom:latitude":38.174833,
     "geom:longitude":68.915483,
@@ -105,9 +105,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.KL.JA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892926,
-    "wof:geomhash":"642ab0a834bc0b1be350d34e3777c144",
+    "wof:geomhash":"8bcefffb94c80f9ffcd798192419b22d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091918301,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886529,
     "wof:name":"Yovon",
     "wof:parent_id":85678905,
     "wof:placetype":"county",

--- a/data/109/191/833/9/1091918339.geojson
+++ b/data/109/191/833/9/1091918339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050522,
-    "geom:area_square_m":477445958.693928,
+    "geom:area_square_m":477446077.527922,
     "geom:bbox":"68.534118,40.086061,69.181679,40.229414",
     "geom:latitude":40.158209,
     "geom:longitude":68.882499,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.LE.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892928,
-    "wof:geomhash":"be44de756d321146433518601b11774d",
+    "wof:geomhash":"7b9682553ce3ad611f1514b7cb36a1f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091918339,
-    "wof:lastmodified":1627522823,
+    "wof:lastmodified":1695886529,
     "wof:name":"Zafarobod",
     "wof:parent_id":85678913,
     "wof:placetype":"county",

--- a/data/109/191/838/1/1091918381.geojson
+++ b/data/109/191/838/1/1091918381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.20548,
-    "geom:area_square_m":1995611169.334704,
+    "geom:area_square_m":1995611169.33457,
     "geom:bbox":"68.1809390713,37.7658900068,68.9435963806,38.6413666816",
     "geom:latitude":38.239155,
     "geom:longitude":68.572437,
@@ -198,9 +198,10 @@
     "wof:concordances":{
         "hasc:id":"TJ.RR.LE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TJ",
     "wof:created":1473892929,
-    "wof:geomhash":"4e849acab1e26414884d8bfb11731382",
+    "wof:geomhash":"1505637dd29b533a80c36b5bffafbc45",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -210,7 +211,7 @@
         }
     ],
     "wof:id":1091918381,
-    "wof:lastmodified":1566666474,
+    "wof:lastmodified":1695886576,
     "wof:name":"Rudaki",
     "wof:parent_id":85678907,
     "wof:placetype":"county",

--- a/data/856/325/13/85632513.geojson
+++ b/data/856/325/13/85632513.geojson
@@ -1259,6 +1259,7 @@
         "hasc:id":"TJ",
         "icao:code":"EY",
         "ioc:id":"TJK",
+        "iso:code":"TJ",
         "itu:id":"TJK",
         "loc:id":"n91129915",
         "m49:code":"762",
@@ -1272,6 +1273,7 @@
         "wk:page":"Tajikistan",
         "wmo:id":"TA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TJ",
     "wof:country_alpha3":"TJK",
     "wof:geom_alt":[
@@ -1293,7 +1295,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1694639503,
+    "wof:lastmodified":1695881157,
     "wof:name":"Tajikistan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/788/99/85678899.geojson
+++ b/data/856/788/99/85678899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.326192,
-    "geom:area_square_m":61565014485.533791,
+    "geom:area_square_m":61565014434.149406,
     "geom:bbox":"70.244612,36.672037,75.153826,39.473738",
     "geom:latitude":38.08726,
     "geom:longitude":72.893065,
@@ -334,17 +334,19 @@
         "gn:id":1221692,
         "gp:id":20070296,
         "hasc:id":"TJ.BK",
+        "iso:code":"TJ-GB",
         "iso:id":"TJ-GB",
         "qs_pg:id":1085813,
         "unlc:id":"TJ-GB",
         "wd:id":"Q207319",
         "wk:page":"Gorno-Badakhshan Autonomous Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ee801d2d08ffb29911253c91ff6e5748",
+    "wof:geomhash":"6b7b624ab497dc788fa2865225234746",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -359,7 +361,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1690869259,
+    "wof:lastmodified":1695884782,
     "wof:name":"Gorno-Badakhshan",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/05/85678905.geojson
+++ b/data/856/789/05/85678905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.346684,
-    "geom:area_square_m":22927948663.725529,
+    "geom:area_square_m":22927949395.92347,
     "geom:bbox":"67.784204,36.922609,70.4533,38.699032",
     "geom:latitude":37.798815,
     "geom:longitude":69.133467,
@@ -341,17 +341,19 @@
         "gn:id":1347488,
         "gp:id":20070295,
         "hasc:id":"TJ.KL",
+        "iso:code":"TJ-KT",
         "iso:id":"TJ-KT",
         "qs_pg:id":219916,
         "unlc:id":"TJ-KT",
         "wd:id":"Q633511",
         "wk:page":"Khatlon Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8e577e6ec53c5f874808b347abcb9e3",
+    "wof:geomhash":"9e6db7f0368266e1b832182ac367ceae",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1690869260,
+    "wof:lastmodified":1695884331,
     "wof:name":"Khatlon",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/07/85678907.geojson
+++ b/data/856/789/07/85678907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.150092,
-    "geom:area_square_m":30332811177.482124,
+    "geom:area_square_m":30332811177.480797,
     "geom:bbox":"68.056901,37.76589,72.244434,39.625094",
     "geom:latitude":38.854198,
     "geom:longitude":70.176177,
@@ -298,15 +298,17 @@
         "gn:id":6452615,
         "gp:id":20070297,
         "hasc:id":"TJ.RR",
+        "iso:code":"TJ-RA",
         "qs_pg:id":1085814,
         "wd:id":"Q633490",
         "wk:page":"Districts of Republican Subordination"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d2404ffad1a83879dd650f4acfe9420",
+    "wof:geomhash":"2093b992abf1d9cb1b43fe431e2d3a70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1690869260,
+    "wof:lastmodified":1695884782,
     "wof:name":"Tadzhikistan Territories",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/13/85678913.geojson
+++ b/data/856/789/13/85678913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.781076,
-    "geom:area_square_m":26428851490.000008,
+    "geom:area_square_m":26428851738.143646,
     "geom:bbox":"67.342012,38.878695,70.992426,41.044367",
     "geom:latitude":39.774197,
     "geom:longitude":69.240827,
@@ -364,16 +364,18 @@
         "gn:id":1221092,
         "gp:id":20070294,
         "hasc:id":"TJ.LE",
+        "iso:code":"TJ-SU",
         "iso:id":"TJ-SU",
         "qs_pg:id":219915,
         "wd:id":"Q241582",
         "wk:page":"Sughd Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"21be179bfa7ae7fc6760bb727b53d0eb",
+    "wof:geomhash":"1912a735062fb57404697848fe5c9558",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -388,7 +390,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1690869260,
+    "wof:lastmodified":1695884783,
     "wof:name":"Leninabad",
     "wof:parent_id":85632513,
     "wof:placetype":"region",

--- a/data/856/789/17/85678917.geojson
+++ b/data/856/789/17/85678917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008549,
-    "geom:area_square_m":82662487.303495,
+    "geom:area_square_m":82662487.303488,
     "geom:bbox":"68.7193461334,38.4912045922,68.8247945223,38.630105438",
     "geom:latitude":38.554299,
     "geom:longitude":68.770015,
@@ -523,13 +523,15 @@
         "gn:id":7280679,
         "gp:id":-20070297,
         "hasc:id":"TJ.DU",
+        "iso:code":"TJ-DU",
         "iso:id":"TJ-DU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"TJ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b1309e7f59126499e8e9dce96f513b1",
+    "wof:geomhash":"63f00d8c687d018f1d7df36607144702",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -544,7 +546,7 @@
     "wof:lang_x_spoken":[
         "tgk"
     ],
-    "wof:lastmodified":1582314956,
+    "wof:lastmodified":1695884332,
     "wof:name":"Dushanbe",
     "wof:parent_id":85632513,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.